### PR TITLE
Resolve issue with cmo patient id correction handler

### DIFF
--- a/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
+++ b/persistence/src/main/java/org/mskcc/smile/persistence/neo4j/SmileSampleRepository.java
@@ -86,7 +86,7 @@ public interface SmileSampleRepository extends Neo4jRepository<SmileSample, UUID
 
     @Query("MATCH (s: Sample {smileSampleId: $smileSampleId}) "
             + "MATCH (p: Patient {smilePatientId: $smilePatientId}) "
-            + "CREATE (s)<-[:HAS_SAMPLE]-(p)")
+            + "MERGE (s)<-[:HAS_SAMPLE]-(p)")
     void updateSamplePatientRelationship(@Param("smileSampleId") UUID smileSampleId,
             @Param("smilePatientId") UUID smilePatientId);
 

--- a/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
+++ b/service/src/main/java/org/mskcc/smile/service/impl/SampleServiceImpl.java
@@ -73,7 +73,6 @@ public class SampleServiceImpl implements SmileSampleService {
                             existingSample.getPatient().getSmilePatientId());
                     existingSample.setPatient(sample.getPatient());
                 }
-                existingSample.setPatient(sample.getPatient());
             }
             sampleRepository.save(existingSample);
             return existingSample;


### PR DESCRIPTION
Specifically the error that was occuring was that the message handler
was still making a call to reuse/rename a patient node which isn't necessary
anymore since patient swapping is handled in the sampleService.saveSample() layer

Samples were getting swapped successfully but at after swapping the samples to the new
patient node, the node was still hanging around but with the updated cmo patient id
which threw an error when attempting to fetch a singular patient node by the given id
since there were now 2 patient nodes with that alias.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
